### PR TITLE
fix: improve deployment restart

### DIFF
--- a/deploy-manager/CHANGELOG.md
+++ b/deploy-manager/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ```log
+1.1.0 - 07/26/2023
+-- fix: allow restart of additional deployments using the same ECR repo
+
 1.0.0 - 11/04/2022
 -- feat: add optional flags
 -- feat: add namespace auto search

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -4,7 +4,7 @@
 # @author       Northon Torga <northontorga+github@gmail.com>
 # @license      Apache License 2.0
 # @requires     bash v4+, aws cli v2.1+, curl 7.76+
-# @version      1.0.0
+# @version      1.1.0
 # @crontab      1-59/2 * * * * bash /opt/deploy-manager/DeployManager.sh >/dev/null 2>&1
 #
 

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -308,14 +308,16 @@ for deploy in ${kubeDeployments[*]}; do
         kubeNamespace=$(echo "${deploy}" | awk -F'|' '{print $3}')
     fi
 
-    if ! isDeploymentUsingLatestImage "${deployName}" "${ecrRepositoryName}" "${kubeNamespace}"; then
-        runScript "pre" "${deployName}"
-
-        logAction "Restarting '${deployName}'."
-        restartDeploy "${deployName}" "${kubeNamespace}"
-
-        runScript "post" "${deployName}"
+    if isDeploymentUsingLatestImage "${deployName}" "${ecrRepositoryName}" "${kubeNamespace}"; then
+        continue
     fi
+
+    runScript "pre" "${deployName}"
+
+    logAction "Restarting '${deployName}'."
+    restartDeploy "${deployName}" "${kubeNamespace}"
+
+    runScript "post" "${deployName}"
 
     if isThereNewEcrImage "${ecrRepositoryName}"; then
         logAction "Found outdated images on '${ecrRepositoryName}'."

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -308,16 +308,19 @@ for deploy in ${kubeDeployments[*]}; do
         kubeNamespace=$(echo "${deploy}" | awk -F'|' '{print $3}')
     fi
 
-    if ! isThereNewEcrImage "${ecrRepositoryName}"; then continue; fi
-    logAction "Found outdated images on '${ecrRepositoryName}'."
-
+    if ! isDeploymentUsingLatestImage "${deployName}" "${ecrRepositoryName}" "${kubeNamespace}"; then
         runScript "pre" "${deployName}"
 
         logAction "Restarting '${deployName}'."
         restartDeploy "${deployName}" "${kubeNamespace}"
 
         runScript "post" "${deployName}"
+    fi
+
+    if isThereNewEcrImage "${ecrRepositoryName}"; then
+        logAction "Found outdated images on '${ecrRepositoryName}'."
 
         logAction "Deleting outdated images on '${ecrRepositoryName}'."
         deleteOutdatedEcrImages "${ecrRepositoryName}"
+    fi
 done

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -230,9 +230,6 @@ function getDeploymentNamespace() {
 function restartDeploy() {
     deploy="${1}"
     kubeNamespace="${2}"
-    if [[ -z "${kubeNamespace}" ]]; then
-        kubeNamespace=$(getDeploymentNamespace "${deploy}")
-    fi
 
     if ! kubectl rollout restart "deploy/${deploy}" -n "${kubeNamespace}"; then
         errorMessage="Unable to restart '${deploy}' deploy at '${appDomain}' platform (${stage})."
@@ -302,6 +299,8 @@ for deploy in ${kubeDeployments[*]}; do
     if [[ -n "${stage}" ]]; then
         ecrRepositoryName="${deploy}-${stage}"
     fi
+
+    kubeNamespace=$(getDeploymentNamespace "${deploy}")
 
     if isNamePiped "${deploy}"; then
         deployName=$(echo "${deploy}" | awk -F'|' '{print $1}')

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -300,12 +300,14 @@ for deploy in ${kubeDeployments[*]}; do
         ecrRepositoryName="${deploy}-${stage}"
     fi
 
-    kubeNamespace=$(getDeploymentNamespace "${deploy}")
-
     if isNamePiped "${deploy}"; then
         deployName=$(echo "${deploy}" | awk -F'|' '{print $1}')
         ecrRepositoryName=$(echo "${deploy}" | awk -F'|' '{print $2}')
         kubeNamespace=$(echo "${deploy}" | awk -F'|' '{print $3}')
+    fi
+
+    if [[ -z "${kubeNamespace}" ]]; then
+        kubeNamespace=$(getDeploymentNamespace "${deployName}")
     fi
 
     if isDeploymentUsingLatestImage "${deployName}" "${ecrRepositoryName}" "${kubeNamespace}"; then

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -224,7 +224,7 @@ function isThereNewEcrImage() {
 #
 function getDeploymentNamespace() {
     deploy="${1}"
-    kubectl get deploy -A | awk "/${deploy}/{print \$1}"
+    kubectl get deploy -A | awk "\$2 == \"${deploy}\" {print \$1}"
 }
 
 function restartDeploy() {


### PR DESCRIPTION
This PR adds a new test to check if more than one deployment is using the same ECR repo.

This check allows the script to restart the additional deployments based on the image the pods are currently running.

Besided that, it fixes a little bug when the namespace variable leaks from one iteration to another, causing some deployment residing on a different namespace than the previous one to not be found on K8s.