### PR TITLE
fix: force namespace to get populated on every iteration

### DIFF
--- a/deploy-manager/CHANGELOG.md
+++ b/deploy-manager/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ```log
+1.1.1 - 07/27/2023
+-- fix: avoid namespace var leak when using piped deploys
+
 1.1.0 - 07/26/2023
 -- fix: allow restart of additional deployments using the same ECR repo
 

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -303,12 +303,9 @@ for deploy in ${kubeDeployments[*]}; do
     if isNamePiped "${deploy}"; then
         deployName=$(echo "${deploy}" | awk -F'|' '{print $1}')
         ecrRepositoryName=$(echo "${deploy}" | awk -F'|' '{print $2}')
-        kubeNamespace=$(echo "${deploy}" | awk -F'|' '{print $3}')
     fi
 
-    if [[ -z "${kubeNamespace}" ]]; then
-        kubeNamespace=$(getDeploymentNamespace "${deployName}")
-    fi
+    kubeNamespace=$(getDeploymentNamespace "${deployName}")
 
     if isDeploymentUsingLatestImage "${deployName}" "${ecrRepositoryName}" "${kubeNamespace}"; then
         continue

--- a/deploy-manager/DeployManager.sh
+++ b/deploy-manager/DeployManager.sh
@@ -4,7 +4,7 @@
 # @author       Northon Torga <northontorga+github@gmail.com>
 # @license      Apache License 2.0
 # @requires     bash v4+, aws cli v2.1+, curl 7.76+
-# @version      1.1.0
+# @version      1.1.1
 # @crontab      1-59/2 * * * * bash /opt/deploy-manager/DeployManager.sh >/dev/null 2>&1
 #
 


### PR DESCRIPTION
This PR forces the deployment namespace to be get at every iteration, avoidind leakage when using piped deployments.